### PR TITLE
Fix Streaming Downloads

### DIFF
--- a/src/Middleware/NoFLoCMiddleware.php
+++ b/src/Middleware/NoFLoCMiddleware.php
@@ -10,7 +10,7 @@ class NoFLoCMiddleware
     {
         $response = $next($request);
 
-        $response->header('Permissions-Policy', 'interest-cohort=()');
+        $response->headers->set('Permissions-Policy', 'interest-cohort=()');
 
         return $response;
     }


### PR DESCRIPTION
Using Laravel's response()->streamDownload() method after installing this package throws an error:

**Call to undefined method Symfony\Component\HttpFoundation\StreamedResponse::header()** 

Using $repsonse->headers->set() fixes this.